### PR TITLE
refactor: Remove hasMegaStone and canGigantamax parameters from selec…

### DIFF
--- a/src/hooks/usePokemonData.ts
+++ b/src/hooks/usePokemonData.ts
@@ -21,7 +21,7 @@ export function usePokemonData(
 
 	// Check Redux storage first
 	const storedData = useSelector((state: RootState) =>
-		speciesId ? selectPokemonData(state, speciesId, form, canGigantamax, hasMegaStone) : null
+		speciesId ? selectPokemonData(state, speciesId, form) : null
 	)
 
 	const [pokemonData, setPokemonDataLocal] = useState<{


### PR DESCRIPTION
This pull request makes a small adjustment to how Pokémon data is retrieved from Redux storage in the `usePokemonData` hook. The change simplifies the selector call by removing unnecessary parameters.

- Simplified the call to `selectPokemonData` in `usePokemonData` by removing the `canGigantamax` and `hasMegaStone` parameters, likely because they are no longer needed or handled elsewhere.…tPokemonData call in usePokemonData hook